### PR TITLE
Preserve querystring during redirection

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,7 +14,7 @@
   </p>
   <script>
     const url = (
-      'https://towerofnix.github.io' + location.pathname + location.hash
+      'https://towerofnix.github.io' + location.pathname + location.search + location.hash
     )
 
     location.replace(url)


### PR DESCRIPTION
In case you use a querystring somewhere; it no longer gets stripped